### PR TITLE
Add a searcher for monitoring dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Here are the GCP resources currently searchable through the workflow:
 | 🗃️ Artifact Registry | Repositories |
 | 🏃‍♂️ Cloud Run | Functions (Gen1), Services (Gen2) |
 | 📋 Cloud Tasks | Queues |
+| 📊 Monitoring | Dashboards |
 
 
 ## Contributing

--- a/gcloud/dashboards.go
+++ b/gcloud/dashboards.go
@@ -1,0 +1,10 @@
+package gcloud
+
+type Dashboard struct {
+	DisplayName string `json:"displayName"`
+	Name        string `json:"name"`
+}
+
+func ListMonitoringDashboards(config *Config) ([]Dashboard, error) {
+	return runGCloudCmd[[]Dashboard](config, "monitoring", "dashboards", "list")
+}

--- a/gcloud/dashboards.go
+++ b/gcloud/dashboards.go
@@ -6,5 +6,6 @@ type Dashboard struct {
 }
 
 func ListMonitoringDashboards(config *Config) ([]Dashboard, error) {
-	return runGCloudCmd[[]Dashboard](config, "monitoring", "dashboards", "list")
+	return runGCloudCmd[[]Dashboard](config,
+	 "monitoring", "dashboards", "list", "--format=json(displayName,name)")
 }

--- a/searchers/monitoring/dashboard.go
+++ b/searchers/monitoring/dashboard.go
@@ -15,7 +15,7 @@ func (s *DashboardSearcher) Search(
 	wf *aw.Workflow, svc *services.Service, cfg *gc.Config, q *parser.Result,
 ) error {
 	builder := resource.NewBuilder(
-		"storage_buckets",
+		"monitoring_dashboards",
 		wf,
 		cfg,
 		q,

--- a/searchers/monitoring/dashboard.go
+++ b/searchers/monitoring/dashboard.go
@@ -1,0 +1,30 @@
+package monitoring
+
+import (
+	aw "github.com/deanishe/awgo"
+
+	gc "github.com/dineshgowda24/alfred-gcp-workflow/gcloud"
+	"github.com/dineshgowda24/alfred-gcp-workflow/parser"
+	"github.com/dineshgowda24/alfred-gcp-workflow/services"
+	"github.com/dineshgowda24/alfred-gcp-workflow/workflow/resource"
+)
+
+type DashboardSearcher struct{}
+
+func (s *DashboardSearcher) Search(
+	wf *aw.Workflow, svc *services.Service, cfg *gc.Config, q *parser.Result,
+) error {
+	builder := resource.NewBuilder(
+		"storage_buckets",
+		wf,
+		cfg,
+		q,
+		gc.ListMonitoringDashboards,
+		func(wf *aw.Workflow, dash gc.Dashboard) {
+			sb := FromGCloudMonitoringDashboard(&dash)
+			resource.NewItem(wf, cfg, sb, svc.Icon())
+		},
+	)
+
+	return builder.Build()
+}

--- a/searchers/monitoring/dto.go
+++ b/searchers/monitoring/dto.go
@@ -1,0 +1,38 @@
+package monitoring
+
+import (
+	"strings"
+
+	"github.com/dineshgowda24/alfred-gcp-workflow/gcloud"
+)
+
+type Dashboard struct {
+	DisplayName string
+	Name        string
+}
+
+func (d Dashboard) Title() string {
+	return d.DisplayName
+}
+
+func (d Dashboard) Subtitle() string {
+	return d.ID()
+}
+
+func (d Dashboard) URL(config *gcloud.Config) string {
+	id := d.ID()
+	return "https://console.cloud.google.com/monitoring/dashboards/builder/" + id + "?project=" + config.Project
+
+}
+
+func (d Dashboard) ID() string {
+	parts := strings.Split(d.Name, "/")
+	return parts[len(parts)-1]
+}
+
+func FromGCloudMonitoringDashboard(board *gcloud.Dashboard) Dashboard {
+	return Dashboard{
+		DisplayName: board.DisplayName,
+		Name:        board.Name,
+	}
+}

--- a/searchers/searcher.go
+++ b/searchers/searcher.go
@@ -2,6 +2,7 @@ package searchers
 
 import (
 	aw "github.com/deanishe/awgo"
+
 	"github.com/dineshgowda24/alfred-gcp-workflow/gcloud"
 	"github.com/dineshgowda24/alfred-gcp-workflow/parser"
 	"github.com/dineshgowda24/alfred-gcp-workflow/searchers/artifactregistry"
@@ -11,6 +12,7 @@ import (
 	"github.com/dineshgowda24/alfred-gcp-workflow/searchers/filestore"
 	"github.com/dineshgowda24/alfred-gcp-workflow/searchers/k8s"
 	"github.com/dineshgowda24/alfred-gcp-workflow/searchers/memorystore"
+	"github.com/dineshgowda24/alfred-gcp-workflow/searchers/monitoring"
 	"github.com/dineshgowda24/alfred-gcp-workflow/searchers/netconnectivity"
 	"github.com/dineshgowda24/alfred-gcp-workflow/searchers/netservices"
 	"github.com/dineshgowda24/alfred-gcp-workflow/searchers/pubsub"
@@ -66,6 +68,7 @@ func GetDefaultRegistry() *Registry {
 			"filestore/instances":           &filestore.InstanceSearcher{},
 			"gke/clusters":                  &k8s.ClusterSearcher{},
 			"memorystore/redis":             &memorystore.RedisInstanceSearcher{},
+			"monitoring/dashboards":         &monitoring.DashboardSearcher{},
 			"netconnectivity/cloudrouter":   &netconnectivity.CloudRouterSearcher{},
 			"netconnectivity/vpngateway":    &netconnectivity.VPNGatewaySearcher{},
 			"netconnectivity/vpntunnel":     &netconnectivity.VPNTunnelSearcher{},

--- a/services.yml
+++ b/services.yml
@@ -576,6 +576,12 @@
   description: Infrastructure and application quality checks
   url: https://console.cloud.google.com/monitoring?project={{ .Project }}
   logo_path: assets/gcp/cloud_monitoring.png
+  sub_services:
+    - id: dashboards
+      name: Dashboards
+      description: Custom dashboards for monitoring
+      url: https://console.cloud.google.com/monitoring/dashboards?project={{ .Project }}
+      logo_path: assets/gcp/cloud_monitoring.png
 - id: netconnectivity
   name: Network Connectivity
   description: Network and hybrid connectivity options


### PR DESCRIPTION
This allows something like `gcp monitoring dashboards my_service`, which then opens that particular dashboard in the browser. I wanted this because I hate having to do a lot of clicking to find the dashboard I want to look at when an alert triggers or if I need some quick info.

If you hit <Enter> before searching it just takes you to the list of dashboards, which also seems helpful.

Note that there's an icon in the GCP console for dashboards but I couldn't find a PNG anywhere so I just reused the monitoring icon. The console UI uses an SVG, but I wasn't sure if it was worth doing a conversion.